### PR TITLE
Use byte versions of regex calls

### DIFF
--- a/internal/filters.go
+++ b/internal/filters.go
@@ -41,14 +41,13 @@ func (f *Filters) FilterRecord(bytes []byte) bool {
 	if f.Greps == nil && f.VGreps == nil {
 		return true
 	}
-	record := string(bytes)
 	for _, re := range f.Greps {
-		if re.FindStringIndex(record) == nil {
+		if !re.Match(bytes) {
 			return false
 		}
 	}
 	for _, re := range f.VGreps {
-		if re.FindStringIndex(record) != nil {
+		if re.Match(bytes) {
 			return false
 		}
 	}


### PR DESCRIPTION
This changes the regex code to use the regex methods that take bytes instead of strings, saving the string allocation.

I don't have a test file as large as yours, but for mine this reliably dropped runtime from ~1.5 seconds to ~1.1 seconds when using regexes.