### PR TITLE
Reduce memory allocations

### DIFF
--- a/internal/counter.go
+++ b/internal/counter.go
@@ -72,14 +72,14 @@ func (t *Counter) Add(bytes []byte) {
 	var topList = t.topAsSortedList()
 	topList = topList[0:t.size]
 	t.threshold = topList[len(topList)-1].Count
-	t.top = make(map[string]*uint64)
+	t.top = make(map[string]*uint64, t.size*2)
 	for _, kc := range topList {
 		t.top[kc.Key] = &kc.Count
 	}
 }
 
 func (t *Counter) topAsSortedList() []*KeyCount {
-	var topList []*KeyCount
+	topList := make([]*KeyCount, 0, len(t.top))
 	for key, count := range t.top {
 		topList = append(topList, &KeyCount{key, *count})
 	}

--- a/internal/keyfinder.go
+++ b/internal/keyfinder.go
@@ -29,17 +29,16 @@ func NewKeyFinder(keys []uint) *KeyFinder {
 
 // This is applied to every record, so efficiency matters
 func (kf *KeyFinder) GetKey(record []byte) ([]byte, error) {
-	var err error
-	key := make([]byte, 0, 100)
-
 	// if there are no keyfinders just return the record, minus any trailing newlines
 	if kf == nil || len(*kf) == 0 {
 		if record[len(record)-1] == '\n' {
 			record = record[0 : len(record)-1]
 		}
-		return record, nil
+		return append([]byte(nil), record...), nil
 	}
 
+	var err error
+	key := make([]byte, 0, 100)
 	field := 0
 	index := 0
 	first := true

--- a/internal/keyfinder.go
+++ b/internal/keyfinder.go
@@ -34,6 +34,8 @@ func (kf *KeyFinder) GetKey(record []byte) ([]byte, error) {
 		if record[len(record)-1] == '\n' {
 			record = record[0 : len(record)-1]
 		}
+		// Make a copy of record as record is a pointing at a buffer that will be reused
+		// and the caller is going to hang onto this.
 		return append([]byte(nil), record...), nil
 	}
 

--- a/internal/segmenter.go
+++ b/internal/segmenter.go
@@ -124,9 +124,9 @@ func readAll(s *Segment, filter *Filters, counter *Counter, kf *KeyFinder, repor
 	var keys [][]byte
 	inBuf := 0
 	for current < s.end {
-		// ReadSlice re-uses the underlying buffer, so we need to be careful
-		// not to hold onto it longer than the next call to ReadSlice.
-		// In this case GetKey needs to never return a direct slice from record.
+		// ReadSlice results are only valid until the next call to Read, so we
+		// to be careful about how long we hang onto the record slice.
+		// In this case GetKey needs to never return a direct subslice of the record.
 		record, err := reader.ReadSlice('\n')
 		if err != nil && err != io.EOF {
 			// not sure what to do here


### PR DESCRIPTION
ReadBytes always returns a copy of the data from its buffer, ReadSlice returns a reference to its buffer instead. This reduces allocations to be relative to the number/size of keys, rather than the size of the input data. On my test data, this resulted in 25-40% reduction in execution time. Worst case is no filters and no field selection, in which case it allocates the same amount of memory as before.