### PR TITLE
count segement results separately and merge later

### DIFF
--- a/internal/counter.go
+++ b/internal/counter.go
@@ -85,34 +85,33 @@ func (t *Counter) GetTop() []*KeyCount {
 	topList := t.topAsSortedList()
 	if len(topList) > t.size {
 		return topList[0:t.size]
-	} else {
-		return topList
 	}
+	return topList
 }
 
 // merge applies the counts from the SegmentCounter into the Counter.
 // Once merged, the SegmentCounter should be discarded.
-func (t *Counter) merge(r segmentCounter) {
-	for r_key, r_count := range r {
+func (t *Counter) merge(segCounter segmentCounter) {
+	for segKey, segCount := range segCounter {
 		// Annoyingly we can't efficiently call Add here because we have
 		// a string not a []byte
-		count, existing_key := t.counts[r_key]
-		if !existing_key {
-			count = r_count
-			t.counts[r_key] = r_count
+		count, existingKey := t.counts[segKey]
+		if !existingKey {
+			count = segCount
+			t.counts[segKey] = segCount
 		} else {
-			*count += *r_count
+			*count += *segCount
 		}
 
 		// big enough to be a top candidate?
 		if *count >= t.threshold {
 			// if it wasn't in t.counts then we already know its not in
 			// t.top
-			if existing_key {
-				_, existing_key = t.top[r_key]
+			if existingKey {
+				_, existingKey = t.top[segKey]
 			}
-			if !existing_key {
-				t.top[r_key] = count
+			if !existingKey {
+				t.top[segKey] = count
 				// has the top set grown enough to compress?
 				if len(t.top) >= (t.size * 2) {
 					t.compact()

--- a/internal/counter.go
+++ b/internal/counter.go
@@ -2,50 +2,39 @@ package topfew
 
 import (
 	"sort"
-	"sync"
 )
 
-// represents a key's occurrence count
+// KeyCount represents a key's occurrence count
 type KeyCount struct {
 	Key   string
 	Count *uint64
 }
 
-// represents a bunch of keys and their occurrence counts, with the highest counts tracked.
+// Counter represents a bunch of keys and their occurrence counts, with the highest counts tracked.
 // threshold represents the minimum count value to qualify for consideration as a top count
 // the "top" map represents the keys & counts encountered so far which are higher than threshold
 // The hash values are pointers not integers for efficiency reasons so you don't have to update the
 //  map[string] mapping, you just update the number the key maps to.
-
 type Counter struct {
 	counts    map[string]*uint64
 	top       map[string]*uint64
 	threshold uint64
 	size      int
-	lock      sync.Mutex
 }
 
 func NewCounter(size int) *Counter {
 	t := new(Counter)
 	t.size = size
-	t.counts = make(map[string]*uint64)
-	t.top = make(map[string]*uint64)
+	t.counts = make(map[string]*uint64, 1024)
+	t.top = make(map[string]*uint64, size*2)
 	return t
 }
 
-func (t *Counter) ConcurrentAddKeys(keys [][]byte) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	for _, key := range keys {
-		t.Add(key)
-	}
-}
-
-// note the call with a byte slice rather than the string because of
-//  https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
-//  which recognizes the idiom foo[string(someByteSlice)] and bypasses constructing the string;
-//  of course we'd rather just say foo[someByteSlice] but that's not legal because Reasons.
 func (t *Counter) Add(bytes []byte) {
+	// note the call with a byte slice rather than the string because of
+	//  https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
+	//  which recognizes the idiom foo[string(someByteSlice)] and bypasses constructing the string;
+	//  of course we'd rather just say foo[someByteSlice] but that's not legal because Reasons.
 
 	// have we seen this key?
 	count, ok := t.counts[string(bytes)]
@@ -64,13 +53,13 @@ func (t *Counter) Add(bytes []byte) {
 	_, ok = t.top[string(bytes)]
 	if !ok {
 		t.top[string(bytes)] = count
+		if len(t.top) >= (t.size * 2) {
+			t.compact()
+		}
 	}
+}
 
-	// has the top set grown enough to compress?
-	if len(t.top) < (t.size * 2) {
-		return
-	}
-
+func (t *Counter) compact() {
 	// sort the top candidates, shrink the list to the top t.size, put them back in a map
 	var topList = t.topAsSortedList()
 	topList = topList[0:t.size]
@@ -93,12 +82,60 @@ func (t *Counter) topAsSortedList() []*KeyCount {
 }
 
 func (t *Counter) GetTop() []*KeyCount {
-	t.lock.Lock()
-	defer t.lock.Unlock()
 	topList := t.topAsSortedList()
 	if len(topList) > t.size {
 		return topList[0:t.size]
 	} else {
 		return topList
+	}
+}
+
+// merge applies the counts from the SegmentCounter into the Counter.
+// Once merged, the SegmentCounter should be discarded.
+func (t *Counter) merge(r segmentCounter) {
+	for r_key, r_count := range r {
+		// Annoyingly we can't efficiently call Add here because we have
+		// a string not a []byte
+		count, existing_key := t.counts[r_key]
+		if !existing_key {
+			count = r_count
+			t.counts[r_key] = r_count
+		} else {
+			*count += *r_count
+		}
+
+		// big enough to be a top candidate?
+		if *count >= t.threshold {
+			// if it wasn't in t.counts then we already know its not in
+			// t.top
+			if existing_key {
+				_, existing_key = t.top[r_key]
+			}
+			if !existing_key {
+				t.top[r_key] = count
+				// has the top set grown enough to compress?
+				if len(t.top) >= (t.size * 2) {
+					t.compact()
+				}
+			}
+		}
+	}
+}
+
+// SegmentCounter tracks key occurrence counts for a single segment.
+type segmentCounter map[string]*uint64
+
+func newSegmentCounter() segmentCounter {
+	return make(segmentCounter, 1024)
+}
+
+func (s segmentCounter) Add(key []byte) {
+	count, ok := s[string(key)]
+	if !ok {
+		var one uint64 = 1
+		count = &one // a little surprised this works, i.e. you can give a local variable permanent life…
+		s[string(key)] = count
+	} else {
+		*count++
 	}
 }

--- a/internal/counter_test.go
+++ b/internal/counter_test.go
@@ -10,7 +10,7 @@ import (
 func Test1KLines(t *testing.T) {
 	file, err := os.Open("../test/data/small")
 	if err != nil {
-		t.Error("Can't open file")
+		t.Fatalf("Can't open file %v", err)
 	}
 	//noinspection ALL
 	defer file.Close()
@@ -61,46 +61,31 @@ func TestTable_Add(t *testing.T) {
 	for _, key := range keys {
 		table.Add([]byte(key))
 	}
-	x := table.GetTop()
 	n4 := uint64(4)
 	n5 := uint64(5)
 	n6 := uint64(6)
 	n7 := uint64(7)
 	n8 := uint64(8)
 
-	wanted := []KeyCount{
+	wanted := []*KeyCount{
 		{"c", &n8},
 		{"g", &n7},
 		{"e", &n6},
 		{"f", &n5},
 		{"a", &n4},
 	}
-	if len(x) != len(wanted) {
-		t.Error("lengths don't match")
-	}
-	// shouldn't deepEqual do this?
-	for i := 0; i < len(wanted); i++ {
-		if x[i].Key != wanted[i].Key || *x[i].Count != *wanted[i].Count {
-			t.Errorf("Mismatch at index %d", i)
-		}
-	}
+	assertKeyCountsEqual(t, wanted, table.GetTop())
 
 	table = NewCounter(3)
 	for _, key := range keys {
 		table.Add([]byte(key))
 	}
-	x = table.GetTop()
-	wanted = []KeyCount{
+	wanted = []*KeyCount{
 		{"c", &n8},
 		{"g", &n7},
 		{"e", &n6},
 	}
-	for i := 0; i < len(wanted); i++ {
-		if x[i].Key != wanted[i].Key || *x[i].Count != *wanted[i].Count {
-			t.Errorf("Mismatch at index %d", i)
-		}
-	}
-
+	assertKeyCountsEqual(t, wanted, table.GetTop())
 }
 
 func Test_newTable(t *testing.T) {
@@ -109,4 +94,48 @@ func Test_newTable(t *testing.T) {
 	if len(top) != 0 {
 		t.Error("new table should be empty")
 	}
+}
+
+func Test_Merge(t *testing.T) {
+	a := NewCounter(10)
+	b := newSegmentCounter()
+	c := newSegmentCounter()
+	for i := 0; i < 50; i++ {
+		b.Add([]byte{byte('A')})
+		b.Add([]byte{byte('B')})
+		c.Add([]byte{byte('C')})
+		c.Add([]byte{byte('A')})
+	}
+	c.Add([]byte{byte('C')})
+	a.merge(b)
+	a.merge(c)
+	exp := []*KeyCount{
+		{"A", pv(100)}, {"C", pv(51)}, {"B", pv(50)},
+	}
+	assertKeyCountsEqual(t, exp, a.GetTop())
+}
+
+func pv(v uint64) *uint64 {
+	return &v
+}
+
+func assertKeyCountsEqual(t *testing.T, exp []*KeyCount, act []*KeyCount) {
+	if len(exp) != len(act) {
+		t.Errorf("Expecting %d results, but got %d", len(exp), len(act))
+	}
+	for i := 0; i < min(len(exp), len(act)); i++ {
+		if exp[i].Key != act[i].Key {
+			t.Errorf("Unexpected key %v at index %d, expecting %v", act[i].Key, i, exp[i].Key)
+		}
+		if *exp[i].Count != *act[i].Count {
+			t.Errorf("Unexpected count of %d at index %d, expecting %d", *act[i].Count, i, *exp[i].Count)
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
Most of this change is to have readAll just count keys, and for them to be merged into the top set counter once the segment has finished. In addition there's 2 small changes that improve things even more. 
 * The readAll buffer size is increased
 * The counter maps are created with a starting size of 1024.

I tried these 2 changes against origin/master and they have only a small effect there. They have a larger impact against this version of counter.
Execution times looks really good now. 2015 iMac, i7 7700, 16G ram, 10 runs against your log file. go 1.15.7

```
rust
real	0m1.724s
real	0m1.738s
real	0m1.827s
real	0m1.783s
real	0m1.776s
real	0m1.777s
real	0m1.742s
real	0m1.764s
real	0m1.844s
real	0m1.803s

origin/master
real	0m1.611s
real	0m1.560s
real	0m1.535s
real	0m1.640s
real	0m1.674s
real	0m1.670s
real	0m1.673s
real	0m1.472s
real	0m1.540s
real	0m1.686s

this PR
real	0m4.700s
real	0m1.148s
real	0m1.106s
real	0m1.093s
real	0m1.107s
real	0m1.126s
real	0m1.110s
real	0m1.073s
real	0m1.137s
real	0m1.058s
```