### PR TITLE
experiment with alternate counter scheme

### DIFF
--- a/internal/counter.go
+++ b/internal/counter.go
@@ -1,7 +1,8 @@
 package topfew
 
 import (
-	"sort"
+	"math/bits"
+	"slices"
 )
 
 // KeyCount represents a key's occurrence count.
@@ -16,18 +17,15 @@ type KeyCount struct {
 // The hash values are pointers not integers for efficiency reasons, so you don't have to update the
 // map[string] mapping, you just update the number the key maps to.
 type Counter struct {
-	counts    map[string]*uint64
-	top       map[string]*uint64
-	threshold uint64
-	size      int
+	counts map[string]uint64
+	size   int
 }
 
 // NewCounter creates a new empty counter, ready for use. Size controls how many top items to track.
 func NewCounter(size int) *Counter {
 	t := new(Counter)
 	t.size = size
-	t.counts = make(map[string]*uint64, 1024)
-	t.top = make(map[string]*uint64, size*2)
+	t.counts = make(map[string]uint64, 1024)
 	return t
 }
 
@@ -39,105 +37,59 @@ func (t *Counter) Add(bytes []byte) {
 	//  of course we'd rather just say foo[someByteSlice] but that's not legal because Reasons.
 
 	// have we seen this key?
-	count, ok := t.counts[string(bytes)]
-	if !ok {
-		var one uint64 = 1
-		count = &one // a little surprised this works, i.e. you can give a local variable permanent life…
-		t.counts[string(bytes)] = count
-	} else {
-		*count++
-	}
-
-	// big enough to be a top candidate?
-	if *count < t.threshold {
-		return
-	}
-	_, ok = t.top[string(bytes)]
-	if !ok {
-		t.top[string(bytes)] = count
-		if len(t.top) >= (t.size * 2) {
-			t.compact()
-		}
-	}
-}
-
-func (t *Counter) compact() {
-	// sort the top candidates, shrink the list to the top t.Size, put them back in a map
-	var topList = t.topAsSortedList()
-	topList = topList[0:t.size]
-	t.threshold = *(topList[len(topList)-1].Count)
-	t.top = make(map[string]*uint64, t.size*2)
-	for _, kc := range topList {
-		t.top[kc.Key] = kc.Count
-	}
-}
-
-func (t *Counter) topAsSortedList() []*KeyCount {
-	topList := make([]*KeyCount, 0, len(t.top))
-	for key, count := range t.top {
-		topList = append(topList, &KeyCount{key, count})
-	}
-	sort.Slice(topList, func(k1, k2 int) bool {
-		return *topList[k1].Count > *topList[k2].Count
-	})
-	return topList
+	t.counts[string(bytes)]++
 }
 
 // GetTop returns the top occurring keys & counts in order of descending count
 func (t *Counter) GetTop() []*KeyCount {
-	topList := t.topAsSortedList()
-	if len(topList) > t.size {
-		return topList[0:t.size]
+	keys := make([]string, 0, len(t.counts))
+	packedCounts := make([]uint64, 0, len(t.counts))
+
+	// calculate how many bits of the counter space should be dedicated to key space
+	shift := 64 - bits.LeadingZeros(uint(len(t.counts)))
+	mask := uint64(1<<shift - 1)
+
+	id := 0
+	for key, count := range t.counts {
+		keys = append(keys, key)
+		packed := (count << shift) + uint64(id)
+		packedCounts = append(packedCounts, packed)
+		id++
 	}
-	return topList
+
+	slices.Sort(packedCounts)
+
+	results := make([]*KeyCount, 0, t.size)
+	start := len(packedCounts) - 1
+	end := start - t.size
+	// clamp in case we don't have t.size top values
+	if end < -1 {
+		end = -1
+	}
+	for i := start; i > end; i-- {
+		packed := packedCounts[i]
+		count := packed >> shift
+		key := keys[packed&mask]
+		results = append(results, &KeyCount{key, &count})
+	}
+	return results
 }
 
 // merge applies the counts from the SegmentCounter into the Counter.
 // Once merged, the SegmentCounter should be discarded.
 func (t *Counter) merge(segCounter segmentCounter) {
 	for segKey, segCount := range segCounter {
-		// Annoyingly we can't efficiently call Add here because we have
-		// a string not a []byte
-		count, existingKey := t.counts[segKey]
-		if !existingKey {
-			count = segCount
-			t.counts[segKey] = segCount
-		} else {
-			*count += *segCount
-		}
-
-		// big enough to be a top candidate?
-		if *count >= t.threshold {
-			// if it wasn't in t.counts then we already know it's not in
-			// t.top
-			if existingKey {
-				_, existingKey = t.top[segKey]
-			}
-			if !existingKey {
-				t.top[segKey] = count
-				// has the top set grown enough to compress?
-				if len(t.top) >= (t.size * 2) {
-					t.compact()
-				}
-			}
-		}
+		t.counts[segKey] += segCount
 	}
 }
 
 // SegmentCounter tracks key occurrence counts for a single segment.
-type segmentCounter map[string]*uint64
+type segmentCounter map[string]uint64
 
 func newSegmentCounter() segmentCounter {
 	return make(segmentCounter, 1024)
 }
 
 func (s segmentCounter) Add(key []byte) {
-	count, ok := s[string(key)]
-	if !ok {
-		var one uint64 = 1
-		count = &one // a little surprised this works, i.e. you can give a local variable permanent life…
-		s[string(key)] = count
-	} else {
-		*count++
-	}
+	s[string(key)]++
 }


### PR DESCRIPTION
Feel free to close this out with no action - just something I was toying with locally and thought I'd share. 🙂 

This is an alternate version of counter that relies on packing a key ID into the counts. The upside is no bookkeeping/juggling of two maps, no merging, no pointer indirection/less sparseness, and no use of the sort Func form. The downside is sharing bits between counter and keyspace, so certain datasets (very very high counts and very very high number of unique keys) would be representable in the current version and not in this version. This scenario could be detected and have a fallback, but current code doesn't do it (didn't apply to my use case, kind of an edge case).